### PR TITLE
Remove folder name in script path

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -32,8 +32,8 @@ function publicHandler(request, response) {
   const urlArray = url.split(".");
   const extension = urlArray[1];
   const type = types[extension];
-  
-  const filePath = path.join(__dirname, "..", url);
+
+  const filePath = path.join(__dirname, url);
       fs.readFile(filePath, (error, file) => {
         if (error) {
           console.log(error);

--- a/templates.js
+++ b/templates.js
@@ -8,7 +8,7 @@ function sharedContent(content, navButton) {
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Microblog</title>
-      <link href="week4-JICG/public/style.css" rel="stylesheet">
+      <link href="public/style.css" rel="stylesheet">
   </head>
   <body>
       <header>
@@ -21,7 +21,7 @@ function sharedContent(content, navButton) {
       <footer>
           <p>Copyright</p>
       </footer>
-      <script src="week4-JICG/public/script.js"></script>
+      <script src="public/script.js"></script>
   </body>
   </html>
   `;


### PR DESCRIPTION
Wrong path on static files and handlers function. Up folder ".." removed from handler function. Delete button now working on Heroku. 